### PR TITLE
Move django_file_storage to remote.yml

### DIFF
--- a/corpora-deploy/env_vars/production.yml
+++ b/corpora-deploy/env_vars/production.yml
@@ -94,7 +94,6 @@ upgrade_pip_app: yes
 django_settings_file: settings.py
 django_include_fixtures: yes
 django_isnot_production: false
-django_file_storage: storages.backends.s3boto3.S3BotoStorage
 create_django_superuser: no
 aws_bucket: "{{project_name}}-production-{{aws_region}}"
 aws_staticfiles_bucket: "{{project_name}}-production-static-{{aws_region}}"

--- a/corpora-deploy/env_vars/staging.yml
+++ b/corpora-deploy/env_vars/staging.yml
@@ -99,7 +99,6 @@ upgrade_pip_app: yes
 django_settings_file: settings.py
 django_include_fixtures: yes
 django_isnot_production: true
-django_file_storage: storages.backends.s3boto3.S3Boto3Storage
 create_django_superuser: no
 aws_bucket: "{{project_name}}-staging-{{aws_region}}"
 aws_staticfiles_bucket: "{{project_name}}-staging-static-{{aws_region}}"

--- a/corpora-deploy/group_vars/remote.yml
+++ b/corpora-deploy/group_vars/remote.yml
@@ -29,3 +29,7 @@ ebs_size: 64
 
 
 elasticache_endpoint: corpora-redis.9eqoln.ng.0001.apse2.cache.amazonaws.com
+
+
+# Django
+django_file_storage: storages.backends.s3boto3.S3Boto3Storage


### PR DESCRIPTION
We had a breaking error in production because we were using the wrong storage. Moving this to remote can prevent this in the future